### PR TITLE
FIX: Missing argument in function call

### DIFF
--- a/tasks/helpers/process.js
+++ b/tasks/helpers/process.js
@@ -53,7 +53,7 @@ module.exports = (function () {
         // Resolve dependencies
         file.dependencies.forEach(function (dependency) {
             var referencedFile = general.getFile([dependency.filename], fileMap);
-            var dependencyContent = produceFileContent(referencedFile, fileMap);
+            var dependencyContent = produceFileContent(referencedFile, fileMap, taskConfig);
             var $element = file.content(dependency.element);
 
             referencedFile.isReferenced = true;


### PR DESCRIPTION
produceFileContent recursive call skips config argument.
Add it back.
